### PR TITLE
Change loading order

### DIFF
--- a/src/poggit/virion/devirion/VirionClassLoader.php
+++ b/src/poggit/virion/devirion/VirionClassLoader.php
@@ -30,7 +30,7 @@ class VirionClassLoader extends \BaseClassLoader{
 
 	public function __construct(ClassLoader $parent = null){
 		parent::__construct($parent);
-		$this->messages = new \Threaded();
+		$this->messages = new \Threaded;
 		$this->antigenMap = new \Threaded;
 		$this->mappedClasses = new \Threaded;
 	}


### PR DESCRIPTION
Reason: a main class of a plugin extending or implementing a class on a virion could not be called before, because the implement/extend are called when loading plugins, not when enabling them