### PR TITLE
Follow the changes in pmmp/ClassLoader

### DIFF
--- a/src/poggit/virion/devirion/VirionClassLoader.php
+++ b/src/poggit/virion/devirion/VirionClassLoader.php
@@ -83,11 +83,11 @@ class VirionClassLoader extends BaseClassLoader{
 		return null;
 	}
 
-	public function loadClass($name) : ?bool{
+	public function loadClass($name) : bool{
 		try{
 			return parent::loadClass($name);
 		}catch(\Exception $e){
-			return null;
+			return false;
 		}
 	}
 


### PR DESCRIPTION
Since there is no need to return `null`, will return `false` instead, and since the return value of `loadClass` is not actually used, this will not cause a BCBreak.